### PR TITLE
deps: rm next-tick

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict'
 
 var document = require('global/document')
-var nextTick = require('next-tick')
 
 module.exports = document.addEventListener ? ready : noop
 
 function ready (callback) {
   if (document.readyState === 'complete') {
-    return nextTick(callback)
+    return setTimeout(callback, 0)
   }
 
   document.addEventListener('DOMContentLoaded', function onLoad () {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "index.js"
   ],
   "dependencies": {
-    "global": "~4.3.0",
-    "next-tick": "~0.2.2"
+    "global": "~4.3.0"
   }
 }


### PR DESCRIPTION
Removes the `next-tick` dep to shave about 1kb from resulting bundles. Related to https://github.com/yoshuawuyts/choo/pull/115. Thanks!
