### PR TITLE
remove the global dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-'use strict'
-
-var document = require('global/document')
-
-module.exports = document.addEventListener ? ready : noop
+module.exports = ready
 
 function ready (callback) {
   var state = document.readyState
@@ -14,5 +10,3 @@ function ready (callback) {
     callback()
   })
 }
-
-function noop () {}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
     "index.js"
   ],
   "dependencies": {
-    "global": "~4.3.0"
   }
 }


### PR DESCRIPTION
This removes the `global` dep and makes the function browser-only. I
can't quite come up with a legit reason to run `document-ready` in a
non-browser environment. In the `choo` code we're not running it on the
server either; think it would also make sense to just crash in a server
environment rather than noop.

Related to https://github.com/yoshuawuyts/choo/pull/436. Think this would probs
be a major release. Thanks heaps!